### PR TITLE
chore: use lts/* as node-version in workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node LTS
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: lts/*
           registry-url: 'https://registry.npmjs.org'
           cache: yarn
 

--- a/templates/.github/workflows/pull-request.yml
+++ b/templates/.github/workflows/pull-request.yml
@@ -10,10 +10,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node 18.x
+      - name: Use Node LTS
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: lts/*
           cache: yarn
 
       - name: Install dependencies

--- a/templates/.github/workflows/workflow.yml
+++ b/templates/.github/workflows/workflow.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use Node 18.x
+      - name: Use Node LTS
         uses: actions/setup-node@v3
         with:
-          node-version: 18.x
+          node-version: lts/*
           cache: yarn
 
       - name: Install dependencies


### PR DESCRIPTION
I think it makes sense that workflows are using the current LTS version of Node, but we'll keep `"engines"` locked to a minimum version that we manually update.

This way, most projects are automatically changed to the latest LTS. This might make it easier to keep it all updated.