### PR TITLE
fix: use transform for ts-jest

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,3 +1,4 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
   preset: 'ts-jest/presets/default-esm',
   collectCoverageFrom: ['src/**/*'],
@@ -5,10 +6,9 @@ module.exports = {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
   },
-  globals: {
-    'ts-jest': {
-      tsconfig: 'tsconfig.jest.json',
-      useESM: true,
-    },
+  transform: {
+    // '^.+\\.[tj]sx?$' to process js/ts with `ts-jest`
+    // '^.+\\.m?[tj]sx?$' to process js/ts/mjs/mts with `ts-jest`
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
 };


### PR DESCRIPTION
Define `ts-jest` config under `globals` is deprecated
