### PR TITLE
feat: use jest with typescript

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,5 +1,6 @@
-/** @type {import('ts-jest').JestConfigWithTsJest} */
-module.exports = {
+import type { Config } from 'jest';
+
+const config: Config = {
   preset: 'ts-jest/presets/default-esm',
   collectCoverageFrom: ['src/**/*'],
   testPathIgnorePatterns: ['.*/dist/.*', '.*dist.*'],
@@ -12,3 +13,5 @@ module.exports = {
     '^.+\\.tsx?$': ['ts-jest', { useESM: true }],
   },
 };
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,14 @@
     ],
     "plugins": [
       "jest"
+    ],
+    "overrides": [
+      {
+        "files": "jest.config.*",
+        "rules": {
+          "import/no-default-export": "off"
+        }
+      }
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Since default exports are discoured in @bjerk/eslint-config, I have added a override for it. I also added a upstream PR for it:
https://github.com/bjerkio/eslint-config/pull/191.

Will open a new PR that removes the override if and when that lands.
