### PR TITLE
feat: upgrade to typescript v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "devDependencies": {
     "@bjerk/eslint-config": "^4.0.0",
     "@simenandre/prettier": "3.0.2",
-    "@tsconfig/node-lts-strictest-esm": "^18.12.1",
+    "@tsconfig/esm": "^1.0.3",
+    "@tsconfig/node-lts": "^18.12.1",
+    "@tsconfig/strictest": "^2.0.1",
     "@types/jest": "^29.1.2",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
@@ -39,7 +41,7 @@
     "prettier": "^2.7.1",
     "ts-jest": "^29.0.3",
     "tsx": "^3.12.7",
-    "typescript": "^4.8.4"
+    "typescript": "^5.0.4"
   },
   "keywords": [
     "boilerplate",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,11 @@
     "files": true,
     "esm": true
   },
-  "extends": "@tsconfig/node-lts-strictest-esm/tsconfig.json",
+  "extends": [
+    "@tsconfig/strictest/tsconfig.json",
+    "@tsconfig/node-lts/tsconfig.json",
+    "@tsconfig/esm/tsconfig.json"
+  ],
   "compilerOptions": {
     "module": "node16",
     "moduleResolution": "node16",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,10 +1079,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node-lts-strictest-esm@npm:^18.12.1":
+"@tsconfig/esm@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@tsconfig/esm@npm:1.0.3"
+  checksum: 07216f491c2603fbd7a5c214f39a2efa183c810dabb77d282ae930bab62f99ff7dbb2ddd7372e5e56ce72e8fb55eb92e3ee5dd6a46c0a7f980c1b59c402fa60b
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node-lts@npm:^18.12.1":
   version: 18.12.1
-  resolution: "@tsconfig/node-lts-strictest-esm@npm:18.12.1"
-  checksum: cc7b2464856b6523baf7cab8a965e75eb1379a743d756a153237852310806d774dea5232d075346652a2c14ce82e21d440941e6d57a809c1adf2d3212d0351b6
+  resolution: "@tsconfig/node-lts@npm:18.12.1"
+  checksum: a59f2dc4cb12690585be3ad81a45f56bf6c68df79fdae7b8ef82162706bc37ee126ed08c476888a54eacdae1d22a21e81c247f2706fa59241a4f8acbf4a756ba
+  languageName: node
+  linkType: hard
+
+"@tsconfig/strictest@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "@tsconfig/strictest@npm:2.0.1"
+  checksum: 3a9b913e06c20fee0a002fc22a925370525dd917853dee2e0082de763b10a61a69d72d60d02e243629da94b3e0b98843469a3b063c0ab2a5d6716183867dd114
   languageName: node
   linkType: hard
 
@@ -1996,7 +2010,9 @@ __metadata:
   dependencies:
     "@bjerk/eslint-config": ^4.0.0
     "@simenandre/prettier": 3.0.2
-    "@tsconfig/node-lts-strictest-esm": ^18.12.1
+    "@tsconfig/esm": ^1.0.3
+    "@tsconfig/node-lts": ^18.12.1
+    "@tsconfig/strictest": ^2.0.1
     "@types/jest": ^29.1.2
     "@types/node": ^18
     "@typescript-eslint/eslint-plugin": ^5.39.0
@@ -2014,7 +2030,7 @@ __metadata:
     prettier: ^2.7.1
     ts-jest: ^29.0.3
     tsx: ^3.12.7
-    typescript: ^4.8.4
+    typescript: ^5.0.4
   bin:
     create-bjerk-typescript: ./cmd/create-bjerk-typescript/index.js
   languageName: unknown
@@ -5635,23 +5651,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^4.8.4":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:^5.0.4":
+  version: 5.0.4
+  resolution: "typescript@npm:5.0.4"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: ee000bc26848147ad423b581bd250075662a354d84f0e06eb76d3b892328d8d4440b7487b5a83e851b12b255f55d71835b008a66cbf8f255a11e4400159237db
+  checksum: 82b94da3f4604a8946da585f7d6c3025fff8410779e5bde2855ab130d05e4fd08938b9e593b6ebed165bda6ad9292b230984f10952cf82f0a0ca07bbeaa08172
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^4.8.4#~builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#~builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+  version: 5.0.4
+  resolution: "typescript@patch:typescript@npm%3A5.0.4#~builtin<compat/typescript>::version=5.0.4&hash=b5f058"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 1f8f3b6aaea19f0f67cba79057674ba580438a7db55057eb89cc06950483c5d632115c14077f6663ea76fd09fce3c190e6414bb98582ec80aa5a4eaf345d5b68
+  checksum: d26b6ba97b6d163c55dbdffd9bbb4c211667ebebc743accfeb2c8c0154aace7afd097b51165a72a5bad2cf65a4612259344ff60f8e642362aa1695c760d303ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
extend default tsconfig use combining tsconfigs with array syntax

See [release announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/) for more.

closes #278
