### PR TITLE
feat: bump @bjerk/eslint-config to ^5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,27 +20,20 @@
     "fs-extra": "^11.1.0"
   },
   "devDependencies": {
-    "@bjerk/eslint-config": "^5.0.0",
+    "@bjerk/eslint-config": "^5.2.0",
     "@simenandre/prettier": "5.0.0",
     "@tsconfig/esm": "^1.0.3",
     "@tsconfig/node-lts": "^18.12.1",
     "@tsconfig/strictest": "^2.0.1",
     "@types/jest": "^29.1.2",
     "@types/node": "^18",
-    "@typescript-eslint/eslint-plugin": "^6.0.0",
-    "@typescript-eslint/parser": "^6.0.0",
     "eslint": "^8.25.0",
-    "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-eslint-comments": "^3.2.0",
-    "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^27.1.5",
-    "eslint-plugin-promise": "^6.0.1",
-    "eslint-plugin-unicorn": "^47.0.0",
     "jest": "^29.1.2",
     "prettier": "^3.0.0",
     "ts-jest": "^29.0.3",
     "tsx": "^3.12.7",
-    "typescript": "^5.0.4"
+    "typescript": "^5.1"
   },
   "keywords": [
     "boilerplate",

--- a/yarn.lock
+++ b/yarn.lock
@@ -170,7 +170,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-validator-identifier@npm:^7.19.1, @babel/helper-validator-identifier@npm:^7.22.5":
+"@babel/helper-validator-identifier@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-validator-identifier@npm:7.22.5"
   checksum: 7f0f30113474a28298c12161763b49de5018732290ca4de13cdaefd4fd0d635a6fe3f6686c37a02905fb1e64f21a5ee2b55140cf7b070e729f1bd66866506aea
@@ -416,22 +416,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bjerk/eslint-config@npm:^5.0.0":
-  version: 5.1.0
-  resolution: "@bjerk/eslint-config@npm:5.1.0"
-  peerDependencies:
+"@bjerk/eslint-config@npm:^5.2.0":
+  version: 5.2.0
+  resolution: "@bjerk/eslint-config@npm:5.2.0"
+  dependencies:
     "@typescript-eslint/eslint-plugin": ^6.0.0
     "@typescript-eslint/parser": ^6.0.0
-    eslint: ^7.32.0 || ^8.2.0
     eslint-config-prettier: ^8.8.0
     eslint-plugin-eslint-comments: ^3.2.0
     eslint-plugin-import: ^2.27.5
     eslint-plugin-promise: ^6.1.1
-    eslint-plugin-unicorn: ^47.0.0
+    eslint-plugin-unicorn: ^48.0.0
+  peerDependencies:
+    eslint: ^7.32.0 || ^8.2.0
+    prettier: ^3.0.0
+    typescript: ^5.1.6
   peerDependenciesMeta:
     prettier:
       optional: true
-  checksum: 9d59978f720aa65e4ffdc27ea4313aeda46be56014d103d9142fd24a2930e5a7dfec65b24193c42c03fb0d4c252e2383fedaa6b03919004cd6d5681bb4b60a02
+    typescript:
+      optional: true
+  checksum: fe1631810c98111d55cd9ce73618dba451957a81fb82d76052c0b6ae6b6f5a21eb3f548fc95401bfada1670daa0dcfd10cac590c09b6528850ec10ea411542f4
   languageName: node
   linkType: hard
 
@@ -2065,28 +2070,21 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "create-bjerk-typescript@workspace:."
   dependencies:
-    "@bjerk/eslint-config": ^5.0.0
+    "@bjerk/eslint-config": ^5.2.0
     "@simenandre/prettier": 5.0.0
     "@tsconfig/esm": ^1.0.3
     "@tsconfig/node-lts": ^18.12.1
     "@tsconfig/strictest": ^2.0.1
     "@types/jest": ^29.1.2
     "@types/node": ^18
-    "@typescript-eslint/eslint-plugin": ^6.0.0
-    "@typescript-eslint/parser": ^6.0.0
     eslint: ^8.25.0
-    eslint-config-prettier: ^8.5.0
-    eslint-plugin-eslint-comments: ^3.2.0
-    eslint-plugin-import: ^2.26.0
     eslint-plugin-jest: ^27.1.5
-    eslint-plugin-promise: ^6.0.1
-    eslint-plugin-unicorn: ^47.0.0
     fs-extra: ^11.1.0
     jest: ^29.1.2
     prettier: ^3.0.0
     ts-jest: ^29.0.3
     tsx: ^3.12.7
-    typescript: ^5.0.4
+    typescript: ^5.1
   bin:
     create-bjerk-typescript: ./cmd/create-bjerk-typescript/index.js
   languageName: unknown
@@ -2460,7 +2458,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-prettier@npm:^8.5.0":
+"eslint-config-prettier@npm:^8.8.0":
   version: 8.8.0
   resolution: "eslint-config-prettier@npm:8.8.0"
   peerDependencies:
@@ -2506,7 +2504,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-import@npm:^2.26.0":
+"eslint-plugin-import@npm:^2.27.5":
   version: 2.27.5
   resolution: "eslint-plugin-import@npm:2.27.5"
   dependencies:
@@ -2549,7 +2547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-promise@npm:^6.0.1":
+"eslint-plugin-promise@npm:^6.1.1":
   version: 6.1.1
   resolution: "eslint-plugin-promise@npm:6.1.1"
   peerDependencies:
@@ -2558,11 +2556,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-unicorn@npm:^47.0.0":
-  version: 47.0.0
-  resolution: "eslint-plugin-unicorn@npm:47.0.0"
+"eslint-plugin-unicorn@npm:^48.0.0":
+  version: 48.0.0
+  resolution: "eslint-plugin-unicorn@npm:48.0.0"
   dependencies:
-    "@babel/helper-validator-identifier": ^7.19.1
+    "@babel/helper-validator-identifier": ^7.22.5
     "@eslint-community/eslint-utils": ^4.4.0
     ci-info: ^3.8.0
     clean-regexp: ^1.0.0
@@ -2573,14 +2571,13 @@ __metadata:
     lodash: ^4.17.21
     pluralize: ^8.0.0
     read-pkg-up: ^7.0.1
-    regexp-tree: ^0.1.24
+    regexp-tree: ^0.1.27
     regjsparser: ^0.10.0
-    safe-regex: ^2.1.1
-    semver: ^7.3.8
+    semver: ^7.5.4
     strip-indent: ^3.0.0
   peerDependencies:
-    eslint: ">=8.38.0"
-  checksum: 8d93bd76d54fb44e134c6576e3bda72dbf4c9cb5bae90451ace6acf1c48e6d7329f1e36db1d19266a5da499afeff6bf0c647875d69adc92d546bcc2d8b765cca
+    eslint: ">=8.44.0"
+  checksum: fc42b6ac3018d43cd68a2d91de43a0f761824a15de5f3c201b3369e15dc3675843bae1644de65b9aa87b2cd1f79ea9188087c54477bef9deef924a1200d5219f
   languageName: node
   linkType: hard
 
@@ -4958,7 +4955,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp-tree@npm:^0.1.24, regexp-tree@npm:~0.1.1":
+"regexp-tree@npm:^0.1.27":
   version: 0.1.27
   resolution: "regexp-tree@npm:0.1.27"
   bin:
@@ -5123,15 +5120,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-regex@npm:^2.1.1":
-  version: 2.1.1
-  resolution: "safe-regex@npm:2.1.1"
-  dependencies:
-    regexp-tree: ~0.1.1
-  checksum: 5d734e2193c63ef0cb00f60c0244e0f8a30ecb31923633cd34636808d6a7c4c206d650017953ae1db8bc33967c2f06af33488dea6f038f4e38212beb7bed77b4
-  languageName: node
-  linkType: hard
-
 "safer-buffer@npm:>= 2.1.2 < 3.0.0":
   version: 2.1.2
   resolution: "safer-buffer@npm:2.1.2"
@@ -5157,7 +5145,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4":
+"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.3, semver@npm:^7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:
@@ -5742,7 +5730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.0.4":
+"typescript@npm:^5.1":
   version: 5.1.6
   resolution: "typescript@npm:5.1.6"
   bin:
@@ -5752,7 +5740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@^5.0.4#~builtin<compat/typescript>":
+"typescript@patch:typescript@^5.1#~builtin<compat/typescript>":
   version: 5.1.6
   resolution: "typescript@patch:typescript@npm%3A5.1.6#~builtin<compat/typescript>::version=5.1.6&hash=5da071"
   bin:


### PR DESCRIPTION
This dramatically reduces devDependencies
